### PR TITLE
Add dashboard routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "vue": "^3.5.17",
-    "element-plus": "^2.3.14"
+    "element-plus": "^2.3.14",
+    "vue-router": "^4.2.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,9 +1,8 @@
 <script setup>
-import Login from './components/Login.vue'
 </script>
 
 <template>
-  <Login />
+  <router-view />
 </template>
 
 <style scoped>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,9 @@ import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import './style.css'
 import App from './App.vue'
+import router from './router'
 
 const app = createApp(App)
 app.use(ElementPlus)
+app.use(router)
 app.mount('#app')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,0 +1,17 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Login from '@/components/Login.vue'
+import Dashboard from '@/views/Dashboard.vue'
+
+const routes = [
+  { path: '/login', component: Login },
+  { path: '/dashboard', component: Dashboard },
+  { path: '/', redirect: '/login' }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="dashboard-page">
+    <h1>🎉 欢迎来到仪表盘！</h1>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.dashboard-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: linear-gradient(135deg, #4f86ff, #8b2eff);
+  color: #fff;
+  font-size: 24px;
+}
+</style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add Vue Router setup with login & dashboard routes
- create simple Dashboard page
- use router view in App
- register router in main entry
- configure alias in Vite

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687654b14b48832e86d1579d6220cbba