### PR TITLE
Fix body style to allow scrolling

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- remove `display:flex` and `place-items:center` from global `body` style

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687859d635a8832e8af7a81f0c052bbc