### PR TITLE
Update ResponseEntity default requestId

### DIFF
--- a/backend/src/main/java/com/example/common/ResponseEntity.java
+++ b/backend/src/main/java/com/example/common/ResponseEntity.java
@@ -3,6 +3,7 @@ package com.example.common;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.slf4j.MDC;
 
 import java.time.Instant;
 
@@ -16,15 +17,32 @@ public class ResponseEntity<T> {
     private String requestId;
     private long timestamp;
 
-    public static <T> ResponseEntity<T> ok(T data, String requestId) {
-        return new ResponseEntity<>(0, "success", data, requestId, Instant.now().toEpochMilli());
+    /* ========== 成功 ========== */
+    public static <T> ResponseEntity<T> ok(T data) {
+        return ok(data, null);
     }
 
-    public static <T> ResponseEntity<T> fail(ErrorCode code, String requestId) {
-        return new ResponseEntity<>(code.getCode(), code.getMessage(), null, requestId, Instant.now().toEpochMilli());
+    public static <T> ResponseEntity<T> ok(T data, String reqId) {
+        return new ResponseEntity<>(0, "success", data, defaultReqId(reqId), Instant.now().toEpochMilli());
     }
 
-    public static <T> ResponseEntity<T> fail(ErrorCode code, String message, String requestId) {
-        return new ResponseEntity<>(code.getCode(), message, null, requestId, Instant.now().toEpochMilli());
+    /* ========== 失败 ========== */
+    public static <T> ResponseEntity<T> fail(ErrorCode code) {
+        return fail(code, null);
+    }
+
+    public static <T> ResponseEntity<T> fail(ErrorCode code, String reqId) {
+        return new ResponseEntity<>(code.getCode(), code.getMessage(), null,
+                defaultReqId(reqId), Instant.now().toEpochMilli());
+    }
+
+    public static <T> ResponseEntity<T> fail(ErrorCode code, String message, String reqId) {
+        return new ResponseEntity<>(code.getCode(), message, null,
+                defaultReqId(reqId), Instant.now().toEpochMilli());
+    }
+
+    /* ========== 共用兜底 ========== */
+    private static String defaultReqId(String reqId) {
+        return (reqId != null && !reqId.isEmpty()) ? reqId : MDC.get("requestId");
     }
 }

--- a/backend/src/main/java/com/example/course/controller/CourseController.java
+++ b/backend/src/main/java/com/example/course/controller/CourseController.java
@@ -22,8 +22,8 @@ public class CourseController {
     private final CourseRepository courseRepository;
 
     @GetMapping
-    public ResponseEntity<List<Course>> list(HttpServletRequest request) {
-        return ResponseEntity.ok(courseRepository.findAll(), request.getHeader("X-Request-ID"));
+    public ResponseEntity<List<Course>> list() {
+        return ResponseEntity.ok(courseRepository.findAll());   // 自动兜底 requestId
     }
 
     @PostMapping


### PR DESCRIPTION
## Summary
- default `requestId` in `ResponseEntity` to `MDC` when null
- simplify `CourseController.list` so callers don't pass the header manually

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687874917d44832ea5e28d767322c6e8