### PR TITLE
Add stats overview API

### DIFF
--- a/backend/src/main/java/com/proshine/training/stats/StatsController.java
+++ b/backend/src/main/java/com/proshine/training/stats/StatsController.java
@@ -1,0 +1,21 @@
+package com.proshine.training.stats;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/stats")
+@RequiredArgsConstructor
+@Slf4j
+public class StatsController {
+    private final StatsService statsService;
+
+    @GetMapping("/overview")
+    public StatsOverviewDTO getOverview() {
+        log.debug("Fetching stats overview");
+        return statsService.getOverview();
+    }
+}

--- a/backend/src/main/java/com/proshine/training/stats/StatsOverviewDTO.java
+++ b/backend/src/main/java/com/proshine/training/stats/StatsOverviewDTO.java
@@ -1,0 +1,13 @@
+package com.proshine.training.stats;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class StatsOverviewDTO {
+    private Integer activeUsers;
+    private Integer studyHours;
+    private Integer totalCourses;
+    private Integer publishedExams;
+}

--- a/backend/src/main/java/com/proshine/training/stats/StatsService.java
+++ b/backend/src/main/java/com/proshine/training/stats/StatsService.java
@@ -1,0 +1,20 @@
+package com.proshine.training.stats;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class StatsService {
+
+    public StatsOverviewDTO getOverview() {
+        // TODO: replace with SQL aggregation
+        log.debug("Returning demo stats overview");
+        return StatsOverviewDTO.builder()
+                .activeUsers(135)
+                .studyHours(420)
+                .totalCourses(57)
+                .publishedExams(8)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple stats API for the backend
- add `StatsOverviewDTO`
- add `StatsService` with placeholder data
- expose `/api/v1/stats/overview` via `StatsController`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b0aee4f0832eb74cffd1c6adb92e