### PR TITLE
Wrap controller responses and add global exception handler

### DIFF
--- a/backend/src/main/java/com/proshine/training/auth/AuthController.java
+++ b/backend/src/main/java/com/proshine/training/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.proshine.training.auth;
 
+import com.proshine.training.common.ResponseEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -14,11 +15,15 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public LoginResponse login(@Valid @RequestBody LoginRequest request, BindingResult bindingResult) throws BindException {
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request, BindingResult bindingResult) throws BindException {
         if (bindingResult.hasErrors()) {
             throw new BindException(bindingResult);
         }
-        return authService.login(request.getUsername(), request.getPassword());
+        LoginResponse resp = authService.login(request.getUsername(), request.getPassword());
+        if (resp != null) {
+            return new ResponseEntity<>(200, "success", resp);
+        }
+        return new ResponseEntity<>(500, "fail", null);
     }
 }
 

--- a/backend/src/main/java/com/proshine/training/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/proshine/training/common/GlobalExceptionHandler.java
@@ -1,46 +1,33 @@
 package com.proshine.training.common;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
+import lombok.extern.slf4j.Slf4j;
+import com.proshine.training.common.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
+import javax.validation.ConstraintViolationException;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, Object>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("code", HttpStatus.BAD_REQUEST.value());
-        body.put("message", "Validation failed");
-        body.put("errors", ex.getBindingResult().getFieldErrors().stream()
-                .collect(Collectors.toMap(f -> f.getField(), f -> f.getDefaultMessage())));
-        return ResponseEntity.badRequest().body(body);
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        log.error("Validation error", e);
+        return new ResponseEntity<>(500, e.getMessage(), null);
     }
 
-    @ExceptionHandler(BindException.class)
-    public ResponseEntity<Map<String, Object>> handleBindException(BindException ex) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("code", HttpStatus.BAD_REQUEST.value());
-        body.put("message", "Validation failed");
-        body.put("errors", ex.getBindingResult().getFieldErrors().stream()
-                .collect(Collectors.toMap(f -> f.getField(), f -> f.getDefaultMessage())));
-        return ResponseEntity.badRequest().body(body);
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException e) {
+        log.error("Constraint violation", e);
+        return new ResponseEntity<>(500, e.getMessage(), null);
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException ex) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("code", HttpStatus.INTERNAL_SERVER_ERROR.value());
-        body.put("message", ex.getMessage());
-        body.put("errors", null);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    public ResponseEntity<Object> handleRuntimeException(RuntimeException e) {
+        log.error("Runtime exception", e);
+        return new ResponseEntity<>(500, e.getMessage(), null);
     }
 }
 

--- a/backend/src/main/java/com/proshine/training/common/ResponseEntity.java
+++ b/backend/src/main/java/com/proshine/training/common/ResponseEntity.java
@@ -1,0 +1,14 @@
+package com.proshine.training.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseEntity<T> {
+    private Integer code;
+    private String message;
+    private T data;
+}

--- a/backend/src/main/java/com/proshine/training/common/ResponsePageDataEntity.java
+++ b/backend/src/main/java/com/proshine/training/common/ResponsePageDataEntity.java
@@ -1,0 +1,13 @@
+package com.proshine.training.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponsePageDataEntity<T> {
+    private Long total;
+    private T rows;
+}

--- a/backend/src/main/java/com/proshine/training/stats/StatsController.java
+++ b/backend/src/main/java/com/proshine/training/stats/StatsController.java
@@ -1,5 +1,6 @@
 package com.proshine.training.stats;
 
+import com.proshine.training.common.ResponseEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,8 +15,12 @@ public class StatsController {
     private final StatsService statsService;
 
     @GetMapping("/overview")
-    public StatsOverviewDTO getOverview() {
+    public ResponseEntity<StatsOverviewDTO> getOverview() {
         log.debug("Fetching stats overview");
-        return statsService.getOverview();
+        StatsOverviewDTO dto = statsService.getOverview();
+        if (dto != null) {
+            return new ResponseEntity<>(200, "success", dto);
+        }
+        return new ResponseEntity<>(500, "fail", null);
     }
 }


### PR DESCRIPTION
## Summary
- add ResponseEntity and ResponsePageDataEntity models
- unify controller return types with ResponseEntity
- implement GlobalExceptionHandler using custom ResponseEntity
- unwrap unified responses on the frontend

## Testing
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ba8b6140832eb6f3317bfc19a9fd