### PR TITLE
Fix HTTP utility and login API

### DIFF
--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -5,9 +5,9 @@ export interface LoginDto {
   password: string
 }
 
-export function loginApi(data: LoginDto) {
-  return http.post<{ token: string; user: { id: string; username: string } }>(
-    '/auth/login',
-    data
-  )
-}
+export const loginApi = (data: LoginDto) =>
+  http({ method: 'post', url: '/auth/login', data }) as Promise<{
+    token: string
+    user: { id: string; username: string }
+  }>;
+

--- a/frontend/src/utils/http.ts
+++ b/frontend/src/utils/http.ts
@@ -28,6 +28,18 @@ instance.interceptors.response.use(
     return Promise.reject(err)
   }
 )
-export default function http<T = any>(config: AxiosRequestConfig): Promise<T> {
-  return instance(config)
-}
+
+type AugmentedHttp = AxiosInstance & (<T = any>(cfg: AxiosRequestConfig) => Promise<T>)
+
+const http = instance as AugmentedHttp
+
+http.get = instance.get
+http.post = instance.post
+http.put = instance.put
+http.delete = instance.delete
+http.patch = instance.patch
+http.head = instance.head
+http.options = instance.options
+http.request = instance.request
+
+export default http


### PR DESCRIPTION
## Summary
- implement typed axios wrapper that keeps instance methods
- update login API to use the wrapper's function form

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878bd222414832eaa0078f3aaf7b74e